### PR TITLE
Create fail2ban.service.in

### DIFF
--- a/files/fail2ban.service.in
+++ b/files/fail2ban.service.in
@@ -7,7 +7,6 @@ PartOf=iptables.service firewalld.service ip6tables.service ipset.service nftabl
 [Service]
 Type=simple
 Environment="PYTHONNOUSERSITE=1"
-ExecStartPre=/bin/mkdir -p /run/fail2ban
 ExecStart=@BINDIR@/fail2ban-server -xf start
 # if should be logged in systemd journal, use following line or set logtarget to sysout in fail2ban.local
 # ExecStart=@BINDIR@/fail2ban-server -xf --logtarget=sysout start
@@ -16,6 +15,7 @@ ExecReload=@BINDIR@/fail2ban-client reload
 PIDFile=/run/fail2ban/fail2ban.pid
 Restart=on-failure
 RestartPreventExitStatus=0 255
+RuntimeDirectory=fail2ban
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I am replacing the ExecPreStart which runs the mkdir command to create the runtime directory, instead of using the option 'RuntimeDirectory=fail2ban' which creates the /run/fail2ban, but offers some additional bonuses (see systemd.exec(8) for details).